### PR TITLE
Add leeway parameter when decoding a JWT. Default value is 30 secs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ SECRET="my_super_secret_here"
 ALGORITHM=HS256
 ISSUER="SWO"
 AUDIENCE="modifier"
+LEEWAY=30.0
 # API Client
 DEFAULT_REQUEST_TIMEOUT=10
 # Admin Token

--- a/app/core/auth_jwt_bearer.py
+++ b/app/core/auth_jwt_bearer.py
@@ -14,6 +14,7 @@ JWT_SECRET = settings.secret
 JWT_ALGORITHM = settings.algorithm
 JWT_AUDIENCE = settings.audience
 JWT_ISSUER = settings.issuer
+JWT_LEEWAY = settings.leeway
 
 logger = logging.getLogger("auth_jwt")
 
@@ -42,6 +43,7 @@ def decode_jwt(token: str) -> Optional[dict]:  # noqa: UP007
             options={"require": ["exp", "nbf", "iss", "aud"]},
             audience=JWT_AUDIENCE,
             issuer=JWT_ISSUER,
+            leeway=JWT_LEEWAY
         )
         return decoded_token
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     issuer: str
     audience: str
+    leeway: float = 30.0
     default_request_timeout: int = 10  # API Client
     admin_token: str
     # Database

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -56,10 +56,16 @@ class TestDecodeJWT:
         assert decoded_token["aud"] == JWT_AUDIENCE
 
     def test_decode_jwt_expired_token(self):
-        token = create_jwt_token(subject=SUBJECT, expires_in=-10)  # Expired token
+        token = create_jwt_token(subject=SUBJECT, expires_in=-30)  # Expired token
 
         decoded_token = decode_jwt(token)
         assert decoded_token is None
+
+    def test_decode_jwt_grace_period(self):
+        # the default leeway value is 30sec
+        token = create_jwt_token(subject=SUBJECT, expires_in=-29)
+        decoded_token = decode_jwt(token)
+        assert decoded_token is not None
 
     def test_invalid_signature(self):
         # modify a token to invalidate the signature


### PR DESCRIPTION
I added the `leeway` parameter when decoding a JWT to allow a grace period and mitigate clock drift.
It has a default value of 30 seconds that can be changed by setting the ENV variable `LEEWAY` in the `.env` 